### PR TITLE
Feat/#13 공통 컴포넌트 UserProfile 레이아웃 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-devtools": "^6.1.1",
     "react-dom": "^18",
     "react-hook-form": "^7.54.2",
+    "react-icons": "^5.5.0",
     "shadcn": "2.4.0-canary.17",
     "sharp": "^0.33.5",
     "zod": "^3.24.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.2
         version: 7.54.2(react@18.3.1)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.5.0(react@18.3.1)
       shadcn:
         specifier: 2.4.0-canary.17
         version: 2.4.0-canary.17(@types/node@20.17.24)(typescript@5.8.2)
@@ -2575,6 +2578,11 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -5989,6 +5997,10 @@ snapshots:
       scheduler: 0.23.2
 
   react-hook-form@7.54.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  react-icons@5.5.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,5 +1,5 @@
 const MyPage = () => {
-  return <div>MyPage</div>;
+  return <div></div>;
 };
 
 export default MyPage;

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,5 +1,19 @@
+import UserProfile from '@/ui/common/UserProfile';
+
 const MyPage = () => {
-  return <div></div>;
+  const user = {
+    nick_name: 'Nickname',
+    bio: 'bio',
+    categories: ['런닝', '배드민턴', '축구'],
+  };
+
+  return (
+    <div>
+      <UserProfile user={user} edit={true}>
+        <div>children</div>
+      </UserProfile>
+    </div>
+  );
 };
 
 export default MyPage;

--- a/src/ui/common/UserProfile.tsx
+++ b/src/ui/common/UserProfile.tsx
@@ -1,0 +1,51 @@
+import Image from 'next/image';
+import profileImg from '../../../public/images/found_default_profile01.png';
+import { ReactNode } from 'react';
+import { GrEdit } from 'react-icons/gr';
+
+const UserProfile = ({
+  user,
+  children,
+  edit,
+}: {
+  user: User;
+  children: ReactNode;
+  edit: boolean;
+}) => {
+  const { nick_name, bio, categories } = user;
+
+  return (
+    <div className="flex flex-col gap-5 max-w-[300px]">
+      <Image
+        className="rounded-full"
+        src={profileImg}
+        alt="profile_img"
+        width={250}
+        height={250}
+      />
+      {edit ? (
+        <div className="flex justify-between items-center">
+          <div className="text-title-lg font-bold">{nick_name}</div>
+          <GrEdit />
+        </div>
+      ) : (
+        <div className="text-title-lg font-bold">{nick_name}</div>
+      )}
+      <div className="text-lg">{bio}</div>
+      <div className="flex">
+        {categories.map((category) => (
+          <div key={category}>{category}</div>
+        ))}
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default UserProfile;
+
+type User = {
+  nick_name: string;
+  bio: string;
+  categories: string[];
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,7 +3,7 @@ import type { Config } from 'tailwindcss';
 const config: Config = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/ui/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #13 

<br>

## 📝 작업 내용

> 공통 컴포넌트의 레이아웃을 구성하였습니다.
> 디테일한 디자인은 label 컴포넌트가 완료된 후 추가할 예정입니다.

#### props 설명
> user: 유저 정보 전달
> edit: boolean 값으로, 수정 가능 여부를 확인 ( 추후 로그인된 사용자와 비교하여 자동으로 설정될 예정)
> children: 기본 요소 (닉네임, 상메, 카테고리) 외에 추가 요소 삽입 가능

<br>

## 🖼 스크린샷

<img width="374" alt="image" src="https://github.com/user-attachments/assets/23d2b73b-ac3c-431d-ad3e-b73d8404af1c" />
