### PR TITLE
Feat/#29 Input 공통 컴포넌트 구현

### DIFF
--- a/src/ui/common/CommonInput.tsx
+++ b/src/ui/common/CommonInput.tsx
@@ -4,7 +4,7 @@ import { Textarea } from '../shadcn/textarea';
 type InputProps = {
   placeholder: string;
   isTextarea?: boolean;
-  height?: string;
+  height: number;
 };
 
 const CommonInput = ({
@@ -13,10 +13,10 @@ const CommonInput = ({
   height,
 }: InputProps) => {
   return (
-    <div>
+    <div className="rounded-xl">
       {isTextarea ? (
         <Textarea
-          className={`w-full resize-none bg-main2 h-${height} rounded-xl pl-3 scrollbar-thin scrollbar-thumb-blue-400 scrollbar-track-main2 overflow-y-auto`}
+          className={`w-[60%] resize-none bg-main2 h-${height} scrollbar-thin py-2 scrollbar-thumb-blue-400 scrollbar-track-main2 overflow-y-auto `}
           placeholder={placeholder}
         />
       ) : (

--- a/src/ui/common/CommonInput.tsx
+++ b/src/ui/common/CommonInput.tsx
@@ -16,7 +16,7 @@ const CommonInput = ({
     <div className="rounded-xl">
       {isTextarea ? (
         <Textarea
-          className={`w-[60%] resize-none bg-main2 h-${height} scrollbar-thin py-2 scrollbar-thumb-blue-400 scrollbar-track-main2 overflow-y-auto `}
+          className={`w-full resize-none bg-main2 h-${height} scrollbar-thin py-2 scrollbar-thumb-blue-400 scrollbar-track-main2 overflow-y-auto `}
           placeholder={placeholder}
         />
       ) : (

--- a/src/ui/common/Input.tsx
+++ b/src/ui/common/Input.tsx
@@ -1,0 +1,26 @@
+type InputProps = {
+  placeholder: string;
+  isTextarea?: boolean;
+  height?: string;
+};
+
+const Input = ({ placeholder, isTextarea = false, height }: InputProps) => {
+  return (
+    <div>
+      {isTextarea ? (
+        <textarea
+          className="w-full resize-none bg-main2 h-32 rounded-xl pl-3  placeholder:text-center scrollbar-thin scrollbar-thumb-blue-400 scrollbar-track-main2 overflow-y-auto"
+          placeholder="내용을 입력해주세요."
+        />
+      ) : (
+        <input
+          type="text"
+          className={`w-full bg-main2 h-12 rounded-xl px-3 placeholder:text-center h-${height}`}
+          placeholder={placeholder}
+        />
+      )}
+    </div>
+  );
+};
+
+export default Input;

--- a/src/ui/common/Input.tsx
+++ b/src/ui/common/Input.tsx
@@ -1,21 +1,28 @@
+import { Input } from '../shadcn/input';
+import { Textarea } from '../shadcn/textarea';
+
 type InputProps = {
   placeholder: string;
   isTextarea?: boolean;
   height?: string;
 };
 
-const Input = ({ placeholder, isTextarea = false, height }: InputProps) => {
+const CommonInput = ({
+  placeholder,
+  isTextarea = false,
+  height,
+}: InputProps) => {
   return (
     <div>
       {isTextarea ? (
-        <textarea
-          className="w-full resize-none bg-main2 h-32 rounded-xl pl-3  placeholder:text-center scrollbar-thin scrollbar-thumb-blue-400 scrollbar-track-main2 overflow-y-auto"
-          placeholder="내용을 입력해주세요."
+        <Textarea
+          className={`w-full resize-none bg-main2 h-${height} rounded-xl pl-3 scrollbar-thin scrollbar-thumb-blue-400 scrollbar-track-main2 overflow-y-auto`}
+          placeholder={placeholder}
         />
       ) : (
-        <input
+        <Input
           type="text"
-          className={`w-full bg-main2 h-12 rounded-xl px-3 placeholder:text-center h-${height}`}
+          className={`w-full bg-main2 rounded-xl px-3 h-${height}`}
           placeholder={placeholder}
         />
       )}
@@ -23,4 +30,4 @@ const Input = ({ placeholder, isTextarea = false, height }: InputProps) => {
   );
 };
 
-export default Input;
+export default CommonInput;

--- a/src/ui/shadcn/input.tsx
+++ b/src/ui/shadcn/input.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import { cn } from '@/utils/lib/cn';
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
@@ -8,7 +7,8 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex h-10 w-full rounded-md border border-gray-300 bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'focus:border-blue-500',
           className,
         )}
         ref={ref}

--- a/src/ui/shadcn/input.tsx
+++ b/src/ui/shadcn/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-gray-300 bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex h-10 w-full rounded-md border bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           'focus:border-blue-500',
           className,
         )}

--- a/src/ui/shadcn/textarea.tsx
+++ b/src/ui/shadcn/textarea.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import { cn } from '@/utils/lib/cn';
 
 const Textarea = React.forwardRef<
@@ -9,7 +8,8 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'flex min-h-[80px] w-full rounded-md border  bg-background pl-2 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none disabled:opacity-50 md:text-sm',
+        'focus:border-blue-500',
         className,
       )}
       ref={ref}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #29

<br>

## 📝 작업 내용

> Input 공통 컴포넌트 구현
> textarea로 사용 시 isTextArea={true}
> 높이 조정 시 height={32} -> h-32

<br>

## 🖼 스크린
<img width="433" alt="스크린샷 2025-03-23 오후 4 12 26" src="https://github.com/user-attachments/assets/3ef2532b-cb9e-4d0c-839f-14f5c27367d5" />
<img width="434" alt="스크린샷 2025-03-23 오후 4 12 32" src="https://github.com/user-attachments/assets/ea6ca1b6-15de-48fb-9971-648d57c39eb2" />

<br>