### PR TITLE
Style/#38 로그인/회원가입 페이지 + AuthForm 컴포넌트 디자인

### DIFF
--- a/src/app/@modal/(.)appointment/page.tsx
+++ b/src/app/@modal/(.)appointment/page.tsx
@@ -10,7 +10,6 @@ import { DatePickerDemo } from './_components/DatePickerDemo';
 import { format } from 'date-fns';
 import useClickOutside from '@/hooks/useClickOutside';
 import { useRouter } from 'next/navigation';
-import { PATH } from '@/constants/constants';
 
 type Appointment = {
   title: string;

--- a/src/app/sign/_components/AuthForm.tsx
+++ b/src/app/sign/_components/AuthForm.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { CATEGORIES_SELECT_MODE } from '@/constants/constants';
+import { CATEGORIES_SELECT_MODE, PATH } from '@/constants/constants';
 import { AUTH_MODE } from '@/constants/users';
 import { useAuthContents } from '@/hooks/useAuthContents';
 import { useAuthValidation } from '@/hooks/useAuthValidation';
 import CategorySeletor from '@/ui/common/CategorySeletor';
+import CommonInput from '@/ui/common/CommonInput';
+import Link from 'next/link';
 
 //-----타입 지정-----
 type AuthFormProps = {
@@ -34,9 +36,9 @@ const AuthForm = ({ mode }: AuthFormProps) => {
   });
 
   return (
-    <div>
+    <>
       {/* 폼 양식 */}
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col">
         {loginInputContents.map((item) => {
           const {
             title,
@@ -52,21 +54,24 @@ const AuthForm = ({ mode }: AuthFormProps) => {
           } = item;
 
           return (
-            <div key={id}>
-              <label htmlFor={name}>{title}</label>
-              <input
-                id={id}
-                type={type}
-                placeholder={placeholder}
-                {...register(name, {
-                  required,
-                  minLength,
-                  maxLength,
-                  pattern,
-                })}
-              />
-              {error && <p className="text-red-600">{error.message}</p>}
-            </div>
+            <section key={id} className={INPUT_SECTION}>
+              <label htmlFor={name} className={INPUT_LABLE}>
+                <h6 className={INPUT_TITLE}>{title}</h6>
+                <CommonInput
+                  id={id}
+                  type={type}
+                  placeholder={placeholder}
+                  height={8}
+                  {...register(name, {
+                    required,
+                    minLength,
+                    maxLength,
+                    pattern,
+                  })}
+                />
+              </label>
+              <p className={INPUT_ERROR_TEXT}>{error && error.message}</p>
+            </section>
           );
         })}
 
@@ -88,49 +93,88 @@ const AuthForm = ({ mode }: AuthFormProps) => {
             } = item;
 
             return (
-              <div key={id}>
-                <label htmlFor={name}>{title}</label>
-                <input
-                  id={id}
-                  type={type}
-                  placeholder={placeholder}
-                  {...register(name, {
-                    required,
-                    validate,
-                    minLength,
-                    maxLength,
-                    pattern,
-                  })}
-                />
-                {checkButton && (
-                  <div className="self-end">
-                    <button
-                      type="button"
-                      onClick={() =>
-                        checkNicknameExsited(getValues('nickname'))
-                      }
-                    >
-                      CHECK
-                    </button>
-                  </div>
-                )}
-                {error && <p className="text-red-600">{error.message}</p>}
-              </div>
+              <section key={id} className={INPUT_SECTION}>
+                <label htmlFor={name} className={INPUT_LABLE}>
+                  <h6 className={INPUT_TITLE}>{title}</h6>
+                  <CommonInput
+                    id={id}
+                    type={type}
+                    placeholder={placeholder}
+                    height={8}
+                    {...register(name, {
+                      required,
+                      validate,
+                      minLength,
+                      maxLength,
+                      pattern,
+                    })}
+                  />
+                  {checkButton && (
+                    <div className="self-end">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          checkNicknameExsited(getValues('nickname'))
+                        }
+                      >
+                        CHECK
+                      </button>
+                    </div>
+                  )}
+                </label>
+                <p className={INPUT_ERROR_TEXT}>{error && error.message}</p>
+              </section>
             );
           })}
 
         {mode === AUTH_MODE.SIGNUP && (
-          <CategorySeletor
-            mode={CATEGORIES_SELECT_MODE.AUTH}
-            watch={watch}
-            setValue={setValue}
-          />
+          <section className={INPUT_SECTION}>
+            <label htmlFor="categories" className={INPUT_LABLE}>
+              <p className={INPUT_TITLE}>FAV SPORTS</p>
+              <CategorySeletor
+                mode={CATEGORIES_SELECT_MODE.AUTH}
+                watch={watch}
+                setValue={setValue}
+              />
+            </label>
+          </section>
         )}
 
-        <button type="submit">SUBMIT</button>
+        {/* 로그인/회원가입 이동 버튼 */}
+        <section className="w-full mb-5 pt-3 border-t-2 border-light-gray">
+          {mode === AUTH_MODE.SIGNUP ? (
+            <div className={PAGE_MOVE_WRAPPER}>
+              <p className={PAGE_MOVE_TITLE}>FOUND 회원이신가요?</p>
+              <Link href={PATH.LOGIN} className={PAGE_MOVE_LINK}>
+                LOG IN
+              </Link>
+            </div>
+          ) : (
+            <div className={PAGE_MOVE_WRAPPER}>
+              <p className={PAGE_MOVE_TITLE}>아직 회원이 아니신가요?</p>
+              <Link href={PATH.SIGNUP} className={PAGE_MOVE_LINK}>
+                SIGN UP
+              </Link>
+            </div>
+          )}
+        </section>
+        <button type="submit">
+          {mode === AUTH_MODE.SIGNUP ? 'SIGN UP' : 'LOG IN'}
+        </button>
       </form>
-    </div>
+    </>
   );
 };
+
+//style
+const INPUT_SECTION = 'flex flex-col w-full justify-between items-center p-3';
+const INPUT_LABLE = 'flex w-full justify-between items-center';
+const INPUT_TITLE = 'w-1/3 text-xs md:text-text-lg font-semibold text-main1';
+const INPUT_ERROR_TEXT = 'text-sub1 text-text-sm';
+
+const PAGE_MOVE_WRAPPER = 'w-full flex justify-center items-center gap-10';
+const PAGE_MOVE_TITLE = 'text-text-md';
+const PAGE_MOVE_LINK =
+  'text-text-md font-semibold text-main1 cursor-pointer duration-200 hover:scale-105';
 
 export default AuthForm;

--- a/src/app/sign/_components/AuthForm.tsx
+++ b/src/app/sign/_components/AuthForm.tsx
@@ -6,6 +6,7 @@ import { useAuthContents } from '@/hooks/useAuthContents';
 import { useAuthValidation } from '@/hooks/useAuthValidation';
 import CategorySeletor from '@/ui/common/CategorySeletor';
 import CommonInput from '@/ui/common/CommonInput';
+import { Button } from '@/ui/shadcn/button';
 import Link from 'next/link';
 
 //-----타입 지정-----
@@ -38,7 +39,10 @@ const AuthForm = ({ mode }: AuthFormProps) => {
   return (
     <>
       {/* 폼 양식 */}
-      <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="w-full flex flex-col items-center"
+      >
         {loginInputContents.map((item) => {
           const {
             title,
@@ -96,31 +100,35 @@ const AuthForm = ({ mode }: AuthFormProps) => {
               <section key={id} className={INPUT_SECTION}>
                 <label htmlFor={name} className={INPUT_LABLE}>
                   <h6 className={INPUT_TITLE}>{title}</h6>
-                  <CommonInput
-                    id={id}
-                    type={type}
-                    placeholder={placeholder}
-                    height={8}
-                    {...register(name, {
-                      required,
-                      validate,
-                      minLength,
-                      maxLength,
-                      pattern,
-                    })}
-                  />
-                  {checkButton && (
-                    <div className="self-end">
-                      <button
-                        type="button"
-                        onClick={() =>
-                          checkNicknameExsited(getValues('nickname'))
-                        }
-                      >
-                        CHECK
-                      </button>
-                    </div>
-                  )}
+                  <div className="w-full flex items-center gap-2">
+                    <CommonInput
+                      id={id}
+                      type={type}
+                      placeholder={placeholder}
+                      height={8}
+                      {...register(name, {
+                        required,
+                        validate,
+                        minLength,
+                        maxLength,
+                        pattern,
+                      })}
+                    />
+                    {checkButton && (
+                      <div className="self-end">
+                        <Button
+                          type="button"
+                          onClick={() =>
+                            checkNicknameExsited(getValues('nickname'))
+                          }
+                          variant="subbutton"
+                          size="subbutton"
+                        >
+                          CHECK
+                        </Button>
+                      </div>
+                    )}
+                  </div>
                 </label>
                 <p className={INPUT_ERROR_TEXT}>{error && error.message}</p>
               </section>
@@ -158,10 +166,16 @@ const AuthForm = ({ mode }: AuthFormProps) => {
             </div>
           )}
         </section>
-        <button type="submit">
-          {mode === AUTH_MODE.SIGNUP ? 'SIGN UP' : 'LOG IN'}
-        </button>
+
+        {/* 버튼 */}
+        <div>
+          <Button type="submit" variant="button" size="button">
+            {mode === AUTH_MODE.SIGNUP ? 'SIGN UP' : 'LOG IN'}
+          </Button>
+        </div>
       </form>
+
+      {/* 소셜로그인 */}
     </>
   );
 };

--- a/src/app/sign/login/page.tsx
+++ b/src/app/sign/login/page.tsx
@@ -3,8 +3,11 @@ import AuthForm from '../_components/AuthForm';
 
 const LoginPage = () => {
   return (
-    <div>
-      <AuthForm mode={AUTH_MODE.LOGIN} />
+    <div className="w-full h-[calc(100vh-100px)] flex justify-center items-center">
+      <div className="flex flex-col justify-center items-center w-11/12 md:w-2/5 border-2 border-main1 rounded-3xl p-5">
+        <h3 className="text-title-md font-semibold text-main1 mb-5">LOG IN</h3>
+        <AuthForm mode={AUTH_MODE.LOGIN} />
+      </div>
     </div>
   );
 };

--- a/src/app/sign/signup/page.tsx
+++ b/src/app/sign/signup/page.tsx
@@ -3,8 +3,11 @@ import AuthForm from '../_components/AuthForm';
 
 const SignupPage = () => {
   return (
-    <div>
-      <AuthForm mode={AUTH_MODE.SIGNUP} />
+    <div className="w-full h-[calc(100vh-100px)] flex justify-center items-center">
+      <div className="flex flex-col justify-center items-center w-11/12 md:w-2/5 border-2 border-main1 rounded-3xl p-5">
+        <h3 className="text-title-md font-semibold text-main1 mb-5">SIGN UP</h3>
+        <AuthForm mode={AUTH_MODE.SIGNUP} />
+      </div>
     </div>
   );
 };

--- a/src/hooks/useAuthValidation.ts
+++ b/src/hooks/useAuthValidation.ts
@@ -165,7 +165,6 @@ export const useAuthValidation = (mode: string) => {
 
       //회원가입 성공
       if (data.user) {
-        console.log('data.user', data.user);
         //유저 알람
         toast({ description: AUTH_TOAST_MESSAGES.SIGNUP.SUCCESS });
         //로그인 페이지로 이동

--- a/src/ui/common/CategorySeletor.tsx
+++ b/src/ui/common/CategorySeletor.tsx
@@ -37,22 +37,20 @@ const CategorySeletor = ({ mode, watch, setValue }: CategorySelectorProps) => {
   const categories = Object.values(CATEGORIES);
 
   return (
-    <div className="grid grid-cols-3">
+    <div className="w-full grid grid-cols-3">
       {categories.map((category) => {
         return (
-          <div key={category} className="items-top flex space-x-2">
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id={category}
-                checked={checkedItems.includes(category)}
-                onCheckedChange={(checked) =>
-                  handleChange(category, Boolean(checked))
-                }
-              />
-              <label htmlFor={category} className="text-text-sm font-medium">
-                {category}
-              </label>
-            </div>
+          <div key={category} className="flex items-center gap-2">
+            <Checkbox
+              id={category}
+              checked={checkedItems.includes(category)}
+              onCheckedChange={(checked) =>
+                handleChange(category, Boolean(checked))
+              }
+            />
+            <label htmlFor={category} className="text-text-sm font-medium">
+              {category}
+            </label>
           </div>
         );
       })}

--- a/src/ui/common/CommonInput.tsx
+++ b/src/ui/common/CommonInput.tsx
@@ -3,6 +3,7 @@ import { Textarea } from '../shadcn/textarea';
 import { UseFormRegisterReturn } from 'react-hook-form';
 
 type InputProps = {
+  id?: string;
   placeholder: string;
   isTextarea?: boolean;
   height: number;
@@ -20,6 +21,7 @@ type InputProps = {
 };
 
 const CommonInput = ({
+  id,
   placeholder,
   isTextarea = false,
   height,
@@ -28,16 +30,17 @@ const CommonInput = ({
   ...props
 }: InputProps) => {
   return (
-    <div className="rounded-xl">
+    <>
       {isTextarea ? (
         <Textarea
-          className={`w-full resize-none bg-main2 h-${height} scrollbar-thin py-2 scrollbar-thumb-blue-400 scrollbar-track-main2 overflow-y-auto `}
+          className={`w-full resize-none bg-main2 min-h-${height} scrollbar-thin py-2 scrollbar-thumb-blue-400 scrollbar-track-main2 overflow-y-auto `}
           placeholder={placeholder}
           {...props}
           {...register}
         />
       ) : (
         <Input
+          id={id}
           type={type} // 전달받은 type 사용
           className={`w-full bg-main2 rounded-xl px-3 h-${height}`}
           placeholder={placeholder}
@@ -45,7 +48,7 @@ const CommonInput = ({
           {...register}
         />
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/ui/shadcn/input.tsx
+++ b/src/ui/shadcn/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex w-full rounded-md border bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           'focus:border-blue-500',
           className,
         )}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #38 

<br>

## 📝 작업 내용

> 로그인/회원가입 페이지 css 수정
> CategorySelect 공통 컴포넌트 css 수정

<br>

## 🖼 스크린샷

- Login
<img width="1440" alt="Screenshot 2025-03-24 at 3 59 38 PM" src="https://github.com/user-attachments/assets/53897c44-badc-4923-b7ab-bbbd08807fdf" />

- Signup
<img width="1440" alt="Screenshot 2025-03-24 at 3 59 14 PM" src="https://github.com/user-attachments/assets/4761b214-4231-43fd-9333-eee130b78680" />

<br>

## 💬리뷰 요구사항

> 회원가입 => 주소 컴포넌트는 따로 ISSUE로 빼서 작업중입니다
> 주소 컴포넌트까지 구현하고 따로 PR 남기겠습니다