### PR TITLE
Feat/#43 주소 input 공통 컴포넌트 구현

### DIFF
--- a/src/app/@modal/(.)appointment/page.tsx
+++ b/src/app/@modal/(.)appointment/page.tsx
@@ -9,8 +9,6 @@ import { DatePickerDemo } from './_components/DatePickerDemo';
 import { format } from 'date-fns';
 import useClickOutside from '@/hooks/useClickOutside';
 import { useRouter } from 'next/navigation';
-import AddressInput from '@/ui/common/AddressInput';
-import useAddressChange from '@/hooks/useAddressChange';
 
 type Appointment = {
   title: string;
@@ -30,7 +28,8 @@ const AppointmentPage = () => {
 
   const modalRef = useClickOutside();
 
-  const { place, handlePostcodeSearch, handlePlaceChange } = useAddressChange();
+  //react-hook-form 이후 수정해야함
+  // const { place, handlePostcodeSearch, handlePlaceChange } = useAddressChange();
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -44,7 +43,7 @@ const AppointmentPage = () => {
 
   // 추후 supabase upsert
   const handleAddClick = () => {
-    console.log('appointment', { ...newAppointment, ...place });
+    // console.log('appointment', { ...newAppointment, ...place });
     router.back();
   };
 
@@ -114,11 +113,11 @@ const AppointmentPage = () => {
                 <AppointmentSpan label={'PLACE'} />
                 <div className="flex flex-col gap-1">
                   <>
-                    <AddressInput
-                      place={place}
+                    {/* react-hook-form 이후에 수정 */}
+                    {/* <AddressInput
                       handlePostcodeSearch={handlePostcodeSearch}
                       handlePlaceChange={handlePlaceChange}
-                    />
+                    /> */}
                   </>
                 </div>
               </div>

--- a/src/app/sign/_components/AuthForm.tsx
+++ b/src/app/sign/_components/AuthForm.tsx
@@ -2,8 +2,10 @@
 
 import { CATEGORIES_SELECT_MODE, PATH } from '@/constants/constants';
 import { AUTH_MODE } from '@/constants/users';
+import useAddressChange from '@/hooks/useAddressChange';
 import { useAuthContents } from '@/hooks/useAuthContents';
 import { useAuthValidation } from '@/hooks/useAuthValidation';
+import AddressInput from '@/ui/common/AddressInput';
 import CategorySeletor from '@/ui/common/CategorySeletor';
 import CommonInput from '@/ui/common/CommonInput';
 import { Button } from '@/ui/shadcn/button';
@@ -43,6 +45,7 @@ const AuthForm = ({ mode }: AuthFormProps) => {
         onSubmit={handleSubmit(onSubmit)}
         className="w-full flex flex-col items-center"
       >
+        {/* 이메일 / 비밀번호 */}
         {loginInputContents.map((item) => {
           const {
             title,
@@ -79,6 +82,7 @@ const AuthForm = ({ mode }: AuthFormProps) => {
           );
         })}
 
+        {/* 비밀번호 확인 / 닉네임 / 상태메세지 */}
         {mode === AUTH_MODE.SIGNUP &&
           signUpInputContents.map((item) => {
             const {
@@ -137,6 +141,14 @@ const AuthForm = ({ mode }: AuthFormProps) => {
 
         {mode === AUTH_MODE.SIGNUP && (
           <section className={INPUT_SECTION}>
+            {/* 주소 */}
+            <label htmlFor="address" className={INPUT_LABLE}>
+              <p className={INPUT_TITLE}>ADDRESS</p>
+              <div className="w-full flex flex-col gap-1 mb-4">
+                <AddressInput watch={watch} setValue={setValue} />
+              </div>
+            </label>
+            {/* 카테고리 */}
             <label htmlFor="categories" className={INPUT_LABLE}>
               <p className={INPUT_TITLE}>FAV SPORTS</p>
               <CategorySeletor

--- a/src/hooks/useAddressChange.ts
+++ b/src/hooks/useAddressChange.ts
@@ -1,27 +1,35 @@
 'use client';
 
-import { useState } from 'react';
 import { useFindAddess } from './useFindAddress';
+import { UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import { AuthInputs } from '@/types/users';
 
-const useAddressChange = () => {
-  const [place, setPlace] = useState<{ place: string; detailPlace: string }>({
-    place: '',
-    detailPlace: '',
-  });
+type useAddressChangePros = {
+  setValue: UseFormSetValue<AuthInputs>;
+  watch: UseFormWatch<AuthInputs>;
+};
 
-  const { handlePostcodeSearch } = useFindAddess(setPlace);
+const useAddressChange = ({ setValue, watch }: useAddressChangePros) => {
+  const { handlePostcodeSearch } = useFindAddess(setValue);
 
   const handlePlaceChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     const { name, value } = e.target;
-    setPlace((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
+    setValue(
+      `address.${name}` as 'address.place' | 'address.detailPlace',
+      value,
+    );
   };
 
-  return { place, handlePostcodeSearch, handlePlaceChange };
+  return {
+    place: {
+      place: watch('address.place', ''),
+      detailPlace: watch('address.detailPlace', ''),
+    },
+    handlePostcodeSearch,
+    handlePlaceChange,
+  };
 };
 
 export default useAddressChange;

--- a/src/hooks/useAuthValidation.ts
+++ b/src/hooks/useAuthValidation.ts
@@ -116,8 +116,7 @@ export const useAuthValidation = (mode: string) => {
       checkPassword,
       nickname,
       bio,
-      // 관련 컴포넌트 생성 후 수정할 예정입니다!
-      // address,
+      address,
       categories,
     } = data;
 
@@ -128,7 +127,8 @@ export const useAuthValidation = (mode: string) => {
       !checkPassword ||
       !nickname ||
       !bio ||
-      !categories
+      !categories ||
+      !address
     ) {
       toast({ description: AUTH_ERROR_MESSAGES.ALL_BLANK });
       return;
@@ -153,8 +153,7 @@ export const useAuthValidation = (mode: string) => {
         data: {
           nickname,
           bio,
-          //임시값 입니다!
-          address: '서울시 중랑구',
+          address: `${address.place} ${address.detailPlace}`,
           categories,
         },
       },

--- a/src/hooks/useFindAddress.ts
+++ b/src/hooks/useFindAddress.ts
@@ -1,4 +1,6 @@
+import { AuthInputs } from '@/types/users';
 import { useEffect, useState } from 'react';
+import { UseFormSetValue } from 'react-hook-form';
 
 declare global {
   interface Window {
@@ -6,13 +8,7 @@ declare global {
   }
 }
 
-export const useFindAddess = (
-  setPlace: React.Dispatch<
-    React.SetStateAction<{ place: string; detailPlace: string }>
-  >,
-) => {
-  const [roadAddress, setRoadAddress] = useState('');
-
+export const useFindAddess = (setValue: UseFormSetValue<AuthInputs>) => {
   const [isScriptLoaded, setIsScriptLoaded] = useState(false);
 
   useEffect(() => {
@@ -41,11 +37,8 @@ export const useFindAddess = (
           extraRoadAddr = ` (${extraRoadAddr})`;
         }
 
-        setRoadAddress(data.roadAddress);
-        setPlace({
-          place: data.roadAddress,
-          detailPlace: '',
-        });
+        setValue('address.place', data.roadAddress);
+        setValue('address.detailPlace', '');
       },
     }).open();
   };

--- a/src/services/usersServices.ts
+++ b/src/services/usersServices.ts
@@ -1,4 +1,4 @@
-import { AuthInputs, UserData } from '@/types/users';
+import { AuthInputs, UserMetaData } from '@/types/users';
 import { supabase } from './supabaseClient';
 import { AuthError, Session, User } from '@supabase/supabase-js';
 import { QUERY_KEY } from '@/constants/constants';
@@ -21,7 +21,7 @@ interface SignupResponse {
 }
 
 export const signup = async (
-  newUserData: UserData,
+  newUserData: UserMetaData,
 ): Promise<SignupResponse> => {
   try {
     const { data, error } = await supabase.auth.signUp(newUserData);

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -11,10 +11,9 @@ export type AuthInputs = {
   categories: string[];
 };
 
-export type UserData = {
+export type UserMetaData = {
   email: string;
   password: string;
-  checkPassword: string;
   created_at: number;
   options: {
     data: {

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -4,7 +4,10 @@ export type AuthInputs = {
   checkPassword: string;
   nickname: string;
   bio: string;
-  address: string;
+  address: {
+    place: string;
+    detailPlace: string;
+  };
   categories: string[];
 };
 

--- a/src/ui/common/AddressInput.tsx
+++ b/src/ui/common/AddressInput.tsx
@@ -1,24 +1,23 @@
 'use client';
 
+import { UseFormSetValue, UseFormWatch } from 'react-hook-form';
 import { Button } from '../shadcn/button';
 import CommonInput from './CommonInput';
+import { AuthInputs } from '@/types/users';
+import useAddressChange from '@/hooks/useAddressChange';
 
-type AddressInputProps = {
-  place: {
-    place: string;
-    detailPlace: string;
-  };
-  handlePostcodeSearch: () => void;
-  handlePlaceChange: (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => void;
+type useAddressInput = {
+  setValue: UseFormSetValue<AuthInputs>;
+  watch: UseFormWatch<AuthInputs>;
 };
 
-const AddressInput = ({
-  place,
-  handlePostcodeSearch,
-  handlePlaceChange,
-}: AddressInputProps) => {
+const AddressInput = ({ watch, setValue }: useAddressInput) => {
+  // Address관련 커스텀 훅
+  const { place, handlePostcodeSearch, handlePlaceChange } = useAddressChange({
+    setValue,
+    watch,
+  });
+
   return (
     <>
       <CommonInput


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #43

<br>

## 📝 작업 내용

> 주소input 공통 컴포넌트 분리
> 회원가입 페이지에 추가
> useState => react-hook-form 로직으로 리팩토링

<br>

## 🖼 스크린샷

<img width="1096" alt="Screenshot 2025-03-24 at 8 39 52 PM" src="https://github.com/user-attachments/assets/2e421d49-5b05-4470-b043-ae2b193e9200" />

<br>

## 💬리뷰 요구사항

> 빌드시 `./src/app/matelist/_components/UserCard.tsx:43:14` 에서 타입오류가 발생합니다..! 확인 부탁드립니다..!
> Appointment 페이지 전체를 react-hook-form으로 리팩토링 하기 전까지, 주소 입력 컴포넌트를 주석처리해놓았습니다!
> 종욱님께서 Appointment 페이지 전체 수정하신 이후, react-hook-form으로 리팩토링할 예정입니다!