### PR TITLE
Feat/#24 mateList 기본적인 구현

### DIFF
--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,9 +1,0 @@
-import { createClient } from '@/services/server';
-
-// 작성중인 파일
-export async function GET() {
-  const serverSupabase = await createClient();
-  const { data, error } = await serverSupabase.from('user_categories').select();
-
-  return Response.json(data);
-}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,9 +1,0 @@
-import { createClient } from '@/services/server';
-
-// 작성중인 파일
-export async function GET() {
-  const serverSupabase = await createClient();
-  const { data, error } = await serverSupabase.from('users').select();
-
-  return Response.json(data);
-}

--- a/src/app/matelist/_components/UserCard.tsx
+++ b/src/app/matelist/_components/UserCard.tsx
@@ -5,7 +5,6 @@ import { supabase } from '@/services/supabaseClient';
 import { Avatar } from '@/ui/shadcn/avatar';
 import { Button } from '@/ui/shadcn/button';
 import { useQuery } from '@tanstack/react-query';
-import React from 'react';
 
 type Category = {
   category: 'string';
@@ -84,15 +83,14 @@ const UserCard = ({
             </Button>
           ))}
         </div>
-        {userSession ? (
+        {userSession && (
           <Button
-            variant={'button'} size={"button"}
+            variant={'button'}
+            size={'button'}
             onClick={() => startChat(userSession.id, user.id)}
           >
             CHAT ROOM
           </Button>
-        ) : (
-          <></>
         )}
       </div>
     </article>

--- a/src/app/matelist/_components/UserCard.tsx
+++ b/src/app/matelist/_components/UserCard.tsx
@@ -5,8 +5,11 @@ import { supabase } from '@/services/supabaseClient';
 import { Avatar } from '@/ui/shadcn/avatar';
 import { Button } from '@/ui/shadcn/button';
 import { useQuery } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
-import React, { use } from 'react';
+import React from 'react';
+
+type Category = {
+  category: 'string';
+};
 
 type UserData = {
   id: number;
@@ -17,6 +20,7 @@ type UserData = {
   bio: string;
   user_id: string;
   is_finding: boolean;
+  user_categories: Category[];
 };
 
 const UserCard = ({
@@ -32,13 +36,15 @@ const UserCard = ({
     isPending,
   } = useQuery({
     queryKey: ['loginUser'],
-    queryFn: async () => {
+    queryFn: async (): Promise<UserData> => {
       const { data } = await supabase.auth.getSession();
       const { data: user } = await supabase
         .from('users')
         .select('*')
-        .eq('user_id', data.session?.user.id);
-      return user[0];
+        .eq('user_id', data.session?.user.id)
+        .single();
+
+      return user;
     },
   });
 
@@ -50,6 +56,7 @@ const UserCard = ({
     return <div>Loading...</div>;
   }
 
+  console.log(userSession);
   const startChat = useStartChat();
 
   return (

--- a/src/app/matelist/_components/UserCard.tsx
+++ b/src/app/matelist/_components/UserCard.tsx
@@ -26,8 +26,6 @@ const UserCard = ({
   user: UserData;
   categories: string[];
 }) => {
-  // console.log(user);
-  const router = useRouter();
   const {
     data: userSession,
     isError,
@@ -51,6 +49,7 @@ const UserCard = ({
   if (isPending) {
     return <div>Loading...</div>;
   }
+
   const startChat = useStartChat();
 
   return (

--- a/src/app/matelist/_components/UserCard.tsx
+++ b/src/app/matelist/_components/UserCard.tsx
@@ -84,12 +84,16 @@ const UserCard = ({
             </Button>
           ))}
         </div>
-        <Button
-          className="bg-main1"
-          onClick={() => startChat(userSession.id, user.id)}
-        >
-          CHAT ROOM
-        </Button>
+        {userSession ? (
+          <Button
+            className="bg-main1"
+            onClick={() => startChat(userSession.id, user.id)}
+          >
+            CHAT ROOM
+          </Button>
+        ) : (
+          <></>
+        )}
       </div>
     </article>
   );

--- a/src/app/matelist/_components/UserCard.tsx
+++ b/src/app/matelist/_components/UserCard.tsx
@@ -79,14 +79,14 @@ const UserCard = ({
       <div className="flex flex-col items-center flex-1 pt-5 w-full justify-around">
         <div className="flex flex-row w-full gap-2 flex-wrap">
           {categories.map((category) => (
-            <Button key={category} className="bg-sub1">
+            <Button key={category} variant={'label'} size={'label'}>
               {category}
             </Button>
           ))}
         </div>
         {userSession ? (
           <Button
-            className="bg-main1"
+            variant={'button'} size={"button"}
             onClick={() => startChat(userSession.id, user.id)}
           >
             CHAT ROOM

--- a/src/app/matelist/_components/UserCard.tsx
+++ b/src/app/matelist/_components/UserCard.tsx
@@ -38,11 +38,15 @@ const UserCard = ({
     queryKey: ['loginUser'],
     queryFn: async (): Promise<UserData> => {
       const { data } = await supabase.auth.getSession();
-      const { data: user } = await supabase
+      const { data: user, error } = await supabase
         .from('users')
         .select('*')
         .eq('user_id', data.session?.user.id)
         .single();
+
+      if (error) {
+        throw new Error('사용자 정보를 불러오지 못했습니다.', error);
+      }
 
       return user;
     },
@@ -56,7 +60,6 @@ const UserCard = ({
     return <div>Loading...</div>;
   }
 
-  console.log(userSession);
   const startChat = useStartChat();
 
   return (

--- a/src/app/matelist/_components/UserCard.tsx
+++ b/src/app/matelist/_components/UserCard.tsx
@@ -52,8 +52,6 @@ const UserCard = ({
     },
   });
 
-  const startChat = useStartChat();
-
   if (isError) {
     return <div>Error!</div>;
   }

--- a/src/app/matelist/_components/UserCardList.tsx
+++ b/src/app/matelist/_components/UserCardList.tsx
@@ -7,7 +7,6 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from '@/ui/shadcn/carousel';
-import React from 'react';
 import UserCard from './UserCard';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/services/supabaseClient';

--- a/src/app/matelist/_components/UserCardList.tsx
+++ b/src/app/matelist/_components/UserCardList.tsx
@@ -28,7 +28,13 @@ type UserData = {
   user_categories: Category[];
 };
 
-const UserCardList = ({ category }: { category: string }) => {
+const UserCardList = ({
+  category,
+  userId,
+}: {
+  category: string;
+  userId?: number;
+}) => {
   const {
     data: users,
     isError,
@@ -40,6 +46,10 @@ const UserCardList = ({ category }: { category: string }) => {
         .from('users')
         .select('*, user_categories(category)');
 
+      if (error) {
+        throw new Error('users 데이터를 불러오지 못했습니다', error);
+      }
+
       return data as UserData[];
     },
   });
@@ -47,10 +57,17 @@ const UserCardList = ({ category }: { category: string }) => {
   if (isError) return <div>Error!</div>;
   if (isPending) return <div>Loading!</div>;
 
-  // console.log(users);
-  const filteredUsers = users?.filter((user) =>
-    user.user_categories.some((item) => item.category === category),
+  const filteredUsers = users?.filter(
+    (user) =>
+      user.user_categories.some((item) => item.category === category) &&
+      user.id !== userId,
   );
+
+  if (filteredUsers.length === 0) {
+    return<>
+    <h1>해당 운동을 원하는 파우니가 없어요ㅠ</h1>
+    </>
+  }
 
   return (
     <section className="flex flex-col justify-center items-center">
@@ -85,9 +102,3 @@ const UserCardList = ({ category }: { category: string }) => {
 };
 
 export default UserCardList;
-
-/**
- * 유저 정보 가져오기
- * 유저의 category 가져오기
- * category에 맞는 유저들 가져오기
- */

--- a/src/app/matelist/_components/UserCardList.tsx
+++ b/src/app/matelist/_components/UserCardList.tsx
@@ -45,20 +45,21 @@ type UserCardListProps = {
 };
 
 const UserCardList = ({ category, filteredUsers }: UserCardListProps) => {
+  const userIds = filteredUsers.map((user) => user.user_id);
+
   const {
     data: users,
     isError,
     isPending,
   } = useQuery({
-    queryKey: ['users'],
+    queryKey: ['users', userIds],
     queryFn: async () => {
-      filteredUsers.map(async (filteredUser) => {
-        const { data } = await supabase
-          .from('users')
-          .select('*')
-          .eq('user_id', filteredUser.user_id);
-        return data;
-      });
+      const { data } = await supabase
+        .from('users')
+        .select('*')
+        .in('id', userIds);
+      console.log(data);
+      return data;
     },
   });
 
@@ -73,10 +74,6 @@ const UserCardList = ({ category, filteredUsers }: UserCardListProps) => {
 
   return (
     <section className="flex flex-col justify-center items-center">
-      <div className="flex flex-row w-full lg:max-w-[1380px] md:max-w-2xl pl-1">
-        <Button className="bg-sub1">{CATEGORIES.RUNNING}</Button>
-        <h3 className="text-title-sm pl-3">같이 할 파우니를 찾고있어요!</h3>
-      </div>
       <Carousel
         opts={{
           align: 'start',

--- a/src/app/matelist/_components/UserCardList.tsx
+++ b/src/app/matelist/_components/UserCardList.tsx
@@ -64,9 +64,11 @@ const UserCardList = ({
   );
 
   if (filteredUsers.length === 0) {
-    return<>
-    <h1>해당 운동을 원하는 파우니가 없어요ㅠ</h1>
-    </>
+    return (
+      <div className="flex justify-center item-center">
+        <h1 className="text-title-md text-main1">해당 운동을 원하는 파우니가 없어요ㅠ</h1>
+      </div>
+    );
   }
 
   return (
@@ -75,9 +77,9 @@ const UserCardList = ({
         opts={{
           align: 'start',
         }}
-        className="w-full lg:max-w-[1380px] md:max-w-2xl pt-8"
+        className="w-full pt-8"
       >
-        <CarouselContent className="-ml-0">
+        <CarouselContent className="-ml-0 gap-2">
           {filteredUsers.map((user: UserData, index: number) => {
             const categories = user.user_categories
               .map((item) => Object.values(item))

--- a/src/app/matelist/_components/UserCardListContainer.tsx
+++ b/src/app/matelist/_components/UserCardListContainer.tsx
@@ -76,14 +76,14 @@ const UserCardListContainer = () => {
   }
 
   return (
-    <div>
+    <div className="w-full flex flex-col justify-center items-center">
       {userSession ? (
-        <div>
-          <h1>나의 카테고리</h1>
+        <div className=" lg:max-w-[1380px] md:max-w-2xl pt-8 ">
+          <h1 className="text-title-md text-main1 font-bold">나의 카테고리</h1>
           {myCategories.map((category) => {
             return (
               <div key={category}>
-                <div className="flex flex-row w-full lg:max-w-[1380px] md:max-w-2xl pl-1">
+                <div className="flex flex-row w-full pl-1 pt-10">
                   <Button className="bg-sub1">{category}</Button>
                   <h3 className="text-title-sm pl-3">
                     같이 할 파우니를 찾고있어요!
@@ -93,11 +93,13 @@ const UserCardListContainer = () => {
               </div>
             );
           })}
-          <h1>나의 카테고리 아님</h1>
+          <h1 className="text-title-md text-main1 font-bold pt-10">
+            나의 카테고리 아님
+          </h1>
           {notMyCategories.map((category) => {
             return (
               <div key={category}>
-                <div className="flex flex-row w-full lg:max-w-[1380px] md:max-w-2xl pl-1">
+                <div className="flex flex-row w-full pl-1 pt-10">
                   <Button className="bg-sub1">{category}</Button>
                   <h3 className="text-title-sm pl-3">
                     같이 할 파우니를 찾고있어요!
@@ -110,10 +112,13 @@ const UserCardListContainer = () => {
         </div>
       ) : (
         <div>
+          <h1 className="text-title-md text-main1 font-bold">
+            모집중인 파우니
+          </h1>
           {categoryList.map((category) => {
             return (
               <div key={category}>
-                <div className="flex flex-row w-full lg:max-w-[1380px] md:max-w-2xl pl-1">
+                <div className="flex flex-row w-full pl-1 pt-10">
                   <Button className="bg-sub1">{category}</Button>
                   <h3 className="text-title-sm pl-3">
                     같이 할 파우니를 찾고있어요!

--- a/src/app/matelist/_components/UserCardListContainer.tsx
+++ b/src/app/matelist/_components/UserCardListContainer.tsx
@@ -36,7 +36,7 @@ const UserCardListContainer = () => {
       if (sessionData.session === null) {
         return null;
       }
-      const { data: user } = await supabase
+      const { data: user, error } = await supabase
         .from('users')
         .select(
           `
@@ -48,6 +48,10 @@ const UserCardListContainer = () => {
         )
         .eq('user_id', sessionData.session.user.id)
         .single();
+
+      if (error) {
+        throw new Error('사용자 정보를 불러오지 못했습니다.', error);
+      }
       return user;
     },
   });
@@ -55,12 +59,13 @@ const UserCardListContainer = () => {
   if (isError) return <div>Error...</div>;
   if (isPending) return <div>Loading...</div>;
 
-  // console.log(users);
-  // console.log(userSession);
+  let userId: number;
   let myCategories: string[] = [];
   let notMyCategories: string[] = [];
 
-  if (userSession) {
+  if (userSession && typeof userSession !== undefined) {
+    userId = userSession.id;
+
     myCategories = userSession.user_categories
       .map((item) => Object.values(item))
       .flat();
@@ -84,7 +89,7 @@ const UserCardListContainer = () => {
                     같이 할 파우니를 찾고있어요!
                   </h3>
                 </div>
-                <UserCardList category={category} />
+                <UserCardList category={category} userId={userId} />
               </div>
             );
           })}
@@ -98,14 +103,13 @@ const UserCardListContainer = () => {
                     같이 할 파우니를 찾고있어요!
                   </h3>
                 </div>
-                <UserCardList category={category} />
+                <UserCardList category={category} userId={userId} />
               </div>
             );
           })}
         </div>
       ) : (
         <div>
-          <h1>나의 카테고리 아님</h1>
           {categoryList.map((category) => {
             return (
               <div key={category}>

--- a/src/app/matelist/_components/UserCardListContainer.tsx
+++ b/src/app/matelist/_components/UserCardListContainer.tsx
@@ -79,7 +79,7 @@ const UserCardListContainer = () => {
     <div className="w-full flex flex-col justify-center items-center">
       {userSession ? (
         <div className=" lg:max-w-[1380px] md:max-w-2xl pt-8 ">
-          <h1 className="text-title-md text-main1 font-bold">나의 카테고리</h1>
+          <h1 className="text-title-md text-main1 font-bold">관심있는 카테고리</h1>
           {myCategories.map((category) => {
             return (
               <div key={category}>
@@ -94,7 +94,7 @@ const UserCardListContainer = () => {
             );
           })}
           <h1 className="text-title-md text-main1 font-bold pt-10">
-            나의 카테고리 아님
+            다른 운동 파우니도 찾아보세요
           </h1>
           {notMyCategories.map((category) => {
             return (

--- a/src/app/matelist/_components/UserCardListContainer.tsx
+++ b/src/app/matelist/_components/UserCardListContainer.tsx
@@ -1,5 +1,4 @@
 'use client';
-import React from 'react';
 import UserCardList from './UserCardList';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/services/supabaseClient';

--- a/src/app/matelist/_components/UserCardListContainer.tsx
+++ b/src/app/matelist/_components/UserCardListContainer.tsx
@@ -76,13 +76,29 @@ const UserCardListContainer = () => {
 
   return (
     <div className="w-full flex flex-col justify-center items-center">
-      {userSession ? (
-        <div className=" lg:max-w-[1380px] md:max-w-2xl pt-8 ">
-          <h1 className="text-title-md text-main1 font-bold">
-            관심있는 카테고리
-          </h1>
-          {myCategories.map((category) => {
-            return (
+      <div className="w-full max-w-[1380px] px-4 pt-8">
+        <h1 className="text-title-md text-main1 font-bold">
+          {userSession ? '관심있는 카테고리' : '모집중인 파우니'}
+        </h1>
+
+        {(userSession ? myCategories : categoryList).map((category) => (
+          <div key={category}>
+            <div className="flex flex-row w-full pl-1 pt-10">
+              <Button className="bg-sub1">{category}</Button>
+              <h3 className="text-title-sm pl-3">
+                같이 할 파우니를 찾고있어요!
+              </h3>
+            </div>
+            <UserCardList category={category} userId={userSession?.id} />
+          </div>
+        ))}
+
+        {userSession && notMyCategories.length > 0 && (
+          <>
+            <h1 className="text-title-md text-main1 font-bold pt-10">
+              다른 운동 파우니도 찾아보세요
+            </h1>
+            {notMyCategories.map((category) => (
               <div key={category}>
                 <div className="flex flex-row w-full pl-1 pt-10">
                   <Button className="bg-sub1">{category}</Button>
@@ -90,47 +106,12 @@ const UserCardListContainer = () => {
                     같이 할 파우니를 찾고있어요!
                   </h3>
                 </div>
-                <UserCardList category={category} userId={userId} />
+                <UserCardList category={category} userId={userSession.id} />
               </div>
-            );
-          })}
-          <h1 className="text-title-md text-main1 font-bold pt-10">
-            다른 운동 파우니도 찾아보세요
-          </h1>
-          {notMyCategories.map((category) => {
-            return (
-              <div key={category}>
-                <div className="flex flex-row w-full pl-1 pt-10">
-                  <Button className="bg-sub1">{category}</Button>
-                  <h3 className="text-title-sm pl-3">
-                    같이 할 파우니를 찾고있어요!
-                  </h3>
-                </div>
-                <UserCardList category={category} userId={userId} />
-              </div>
-            );
-          })}
-        </div>
-      ) : (
-        <div className=" lg:max-w-[1380px] md:max-w-2xl pt-8 ">
-          <h1 className="text-title-md text-main1 font-bold">
-            모집중인 파우니
-          </h1>
-          {categoryList.map((category) => {
-            return (
-              <div key={category}>
-                <div className="flex flex-row w-full pl-1 pt-10">
-                  <Button className="bg-sub1">{category}</Button>
-                  <h3 className="text-title-sm pl-3">
-                    같이 할 파우니를 찾고있어요!
-                  </h3>
-                </div>
-                <UserCardList category={category} />
-              </div>
-            );
-          })}
-        </div>
-      )}
+            ))}
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/app/matelist/_components/UserCardListContainer.tsx
+++ b/src/app/matelist/_components/UserCardListContainer.tsx
@@ -79,7 +79,9 @@ const UserCardListContainer = () => {
     <div className="w-full flex flex-col justify-center items-center">
       {userSession ? (
         <div className=" lg:max-w-[1380px] md:max-w-2xl pt-8 ">
-          <h1 className="text-title-md text-main1 font-bold">관심있는 카테고리</h1>
+          <h1 className="text-title-md text-main1 font-bold">
+            관심있는 카테고리
+          </h1>
           {myCategories.map((category) => {
             return (
               <div key={category}>
@@ -111,7 +113,7 @@ const UserCardListContainer = () => {
           })}
         </div>
       ) : (
-        <div>
+        <div className=" lg:max-w-[1380px] md:max-w-2xl pt-8 ">
           <h1 className="text-title-md text-main1 font-bold">
             모집중인 파우니
           </h1>

--- a/src/app/matelist/_components/UserCardListContainer.tsx
+++ b/src/app/matelist/_components/UserCardListContainer.tsx
@@ -1,0 +1,80 @@
+'use client';
+import React from 'react';
+import UserCardList from './UserCardList';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/services/supabaseClient';
+
+const UserCardListContainer = () => {
+  const {
+    data: userSession,
+    isError,
+    isPending,
+  } = useQuery({
+    queryKey: ['loginUser'],
+    queryFn: async () => {
+      const { data } = await supabase.auth.getSession();
+      const { data: user } = await supabase
+        .from('users')
+        .select('*')
+        .eq('user_id', data.session?.user.id);
+      return user[0];
+    },
+  });
+
+  const {
+    data: users,
+    isError: isUsersError,
+    isPending: isUsersPending,
+  } = useQuery({
+    queryKey: ['users'],
+    queryFn: async () => {
+      const { data } = await supabase.from('users').select();
+      return data;
+    },
+  });
+
+  const {
+    data: categories,
+    isError: isCategoriesError,
+    isPending: isCategoriesPending,
+  } = useQuery({
+    queryKey: ['categories'],
+    queryFn: async () => {
+      const { data } = await supabase.from('user_categories').select();
+      return data;
+    },
+  });
+
+  if (isError || isUsersError || isCategoriesError) return <div>Error...</div>;
+  if (isPending || isUsersPending || isCategoriesPending)
+    return <div>Loading...</div>;
+
+  console.log(userSession);
+  console.log(users);
+  console.log(categories);
+
+  const userSessionId = userSession.id;
+
+  const myCategories = categories?.filter(
+    (category) => category.user_id === userSessionId,
+  );
+
+  console.log(myCategories);
+  return (
+    <div>
+      {myCategories.map((myCategory) => {
+        const filteredUsers = categories?.filter((category) => {
+          return category.category === myCategory.category;
+        });
+        console.log(filteredUsers)
+        return (
+          <UserCardList category={myCategory} filteredUsers={filteredUsers} />
+        );
+      })}
+    </div>
+  );
+};
+
+export default UserCardListContainer;
+
+

--- a/src/app/matelist/_components/UserCardListContainer.tsx
+++ b/src/app/matelist/_components/UserCardListContainer.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import UserCardList from './UserCardList';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/services/supabaseClient';
+import { Button } from '@/ui/shadcn/button';
 
 const UserCardListContainer = () => {
   const {
@@ -49,9 +50,9 @@ const UserCardListContainer = () => {
   if (isPending || isUsersPending || isCategoriesPending)
     return <div>Loading...</div>;
 
-  console.log(userSession);
-  console.log(users);
-  console.log(categories);
+  // console.log(userSession);
+  // console.log(users);
+  // console.log(categories);
 
   const userSessionId = userSession.id;
 
@@ -59,16 +60,23 @@ const UserCardListContainer = () => {
     (category) => category.user_id === userSessionId,
   );
 
-  console.log(myCategories);
   return (
     <div>
       {myCategories.map((myCategory) => {
         const filteredUsers = categories?.filter((category) => {
           return category.category === myCategory.category;
         });
-        console.log(filteredUsers)
+        console.log(filteredUsers);
         return (
-          <UserCardList category={myCategory} filteredUsers={filteredUsers} />
+          <>
+            <div className="flex flex-row w-full lg:max-w-[1380px] md:max-w-2xl pl-1">
+              <Button className="bg-sub1">{myCategory.category}</Button>
+              <h3 className="text-title-sm pl-3">
+                같이 할 파우니를 찾고있어요!
+              </h3>
+            </div>
+            <UserCardList category={myCategory} filteredUsers={filteredUsers} />
+          </>
         );
       })}
     </div>
@@ -76,5 +84,3 @@ const UserCardListContainer = () => {
 };
 
 export default UserCardListContainer;
-
-

--- a/src/app/matelist/page.tsx
+++ b/src/app/matelist/page.tsx
@@ -1,27 +1,7 @@
-import { getUsers } from '@/services/getServices';
-import UserCardList from './_components/UserCardList';
-
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
+import UserCardListContainer from './_components/UserCardListContainer';
 
 const MateListPage = async () => {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery({
-    queryKey: ['users'],
-    queryFn: getUsers,
-  });
-
-  return (
-    <div className="">
-      <HydrationBoundary state={dehydrate(queryClient)}>
-        <UserCardList />
-      </HydrationBoundary>
-    </div>
-  );
+  return <UserCardListContainer />;
 };
 
 export default MateListPage;

--- a/src/hooks/useGoChatting.ts
+++ b/src/hooks/useGoChatting.ts
@@ -4,13 +4,13 @@ import { supabase } from '@/services/supabaseClient';
 const useStartChat = () => {
   const router = useRouter();
   const startChat = async (user1_id: number, user2_id: number) => {
-    console.log(user1_id, user2_id);
     // 기존 채팅방 조회
     const { data: existingChat, error } = await supabase
       .from('chat_rooms')
       .select('*')
-      .or(`user1_id.eq.${user1_id},user2_id.eq.${user2_id}`)
-      .or(`user1_id.eq.${user2_id},user2_id.eq.${user1_id}`)
+      .or(
+        `and(user1_id.eq.${user1_id},user2_id.eq.${user2_id}),and(user1_id.eq.${user2_id},user2_id.eq.${user1_id})`,
+      )
       .single();
     console.log(existingChat);
     if (existingChat) {

--- a/src/hooks/useGoChatting.ts
+++ b/src/hooks/useGoChatting.ts
@@ -34,3 +34,5 @@ const useStartChat = () => {
 };
 
 export default useStartChat;
+
+// 왜 계속 새로운 채팅방이 생성되는지 해결해야 함

--- a/src/services/getServices.ts
+++ b/src/services/getServices.ts
@@ -1,9 +1,0 @@
-// 작업중
-export const getUsers = async () => {
-  const res = await fetch('/api/users');
-  if (!res.ok) {
-  }
-
-  const data = await res.json();
-  return data;
-};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #24 

<br>

## 📝 작업 내용

 - 로그인 한 유저 정보 받아오기
 - 선택한 카테고리 별 정렬
 - 나와의 대화 제거
 - 비로그인도 목록 보이게
 - 채팅방 계속 생성되는 문제 수정


<br>

## 🖼 스크린샷

![image](https://github.com/user-attachments/assets/e6c69ccc-fe36-40ad-9dbc-d584092ffc78)

![image](https://github.com/user-attachments/assets/5070de4f-ca25-403f-92d4-fe59c04d551d)

![image](https://github.com/user-attachments/assets/ddb60ba5-9a90-4f69-bc13-94b0eb48db3b)


<br>

## 💬리뷰 요구사항

스타일링은 추후 수정하도록 하겠습니다!
세션은 zustand로 변경되면 
모집중인 파우니, 관심있는 카테고리, 다른 운동 파우니도 찾아보세요 이런 문구들 뭐가 좋을지 의견주시면 감사하겠습니다!