### PR TITLE
Fix/#59 실시간 채팅 공유 문제

### DIFF
--- a/src/app/chatting/_components/Chatting.tsx
+++ b/src/app/chatting/_components/Chatting.tsx
@@ -59,6 +59,7 @@ const Chatting = ({ chatId }: { chatId: number }) => {
 
   const { mutate: sendMessage } = useMutation({
     mutationFn: addMessage,
+    mutationKey: ['messages', chatId],
     onSuccess: () => {
       setNewMessage('');
     },
@@ -69,7 +70,12 @@ const Chatting = ({ chatId }: { chatId: number }) => {
       .channel(`chat-${chatId}`)
       .on(
         'postgres_changes',
-        { event: 'INSERT', schema: 'public', table: 'messages' },
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'messages',
+          filter: `chat_room_id=eq.${chatId}`,
+        },
         (payload) => {
           queryClient.setQueryData(
             ['messages', chatId],


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #59

<br>

## 📝 작업 내용

> 채팅방 구독 시 filter 이용해서 각 채팅방에서만 채팅을 공유할 수 있도록 설정
```typescript
const subscription = supabase
      .channel(`chat-${chatId}`)
      .on(
        'postgres_changes',
        {
          event: 'INSERT',
          schema: 'public',
          table: 'messages',
          filter: `chat_room_id=eq.${chatId}`,
        },
        (payload) => {
          queryClient.setQueryData(
            ['messages', chatId],
            (oldMessages: Message[]) => {
              return [...(oldMessages || []), payload.new];
            },
          );
        },
      )
      .subscribe();
```

<br>