### PR TITLE
Feat#62 메인페이지 2초마다 캐러셀 넘어가도록 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "embla-carousel-autoplay": "^8.5.2",
     "embla-carousel-react": "^8.5.2",
     "html-react-parser": "^5.2.2",
     "lucide-react": "^0.483.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      embla-carousel-autoplay:
+        specifier: ^8.5.2
+        version: 8.5.2(embla-carousel@8.5.2)
       embla-carousel-react:
         specifier: ^8.5.2
         version: 8.5.2(react@18.3.1)
@@ -1775,6 +1778,11 @@ packages:
     resolution: {integrity: sha512-BaXtHEb+KYKLouUXlUVDa/lj9pj4F5kiE0kwFdJV84Y2EU7euIDgPthfKtchhr5MVHmjtavRMIV/zAwEiSQ9rQ==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
+
+  embla-carousel-autoplay@8.5.2:
+    resolution: {integrity: sha512-27emJ0px3q/c0kCHCjwRrEbYcyYUPfGO3g5IBWF1i7714TTzE6L9P81V6PHLoSMAKJ1aHoT2e7YFOsuFKCbyag==}
+    peerDependencies:
+      embla-carousel: 8.5.2
 
   embla-carousel-react@8.5.2:
     resolution: {integrity: sha512-Tmx+uY3MqseIGdwp0ScyUuxpBgx5jX1f7od4Cm5mDwg/dptEiTKf9xp6tw0lZN2VA9JbnVMl/aikmbc53c6QFA==}
@@ -5534,6 +5542,10 @@ snapshots:
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  embla-carousel-autoplay@8.5.2(embla-carousel@8.5.2):
+    dependencies:
+      embla-carousel: 8.5.2
 
   embla-carousel-react@8.5.2(react@18.3.1):
     dependencies:

--- a/src/app/_components/MainCarousel.tsx
+++ b/src/app/_components/MainCarousel.tsx
@@ -49,6 +49,7 @@ const MainCarousel = () => {
                     alt="FOUND"
                     width={100}
                     height={100}
+                    style={{ width: 'auto', height: 'auto' }}
                     className="object-contain"
                   />
                   <FaChevronRight />

--- a/src/app/_components/MainCarousel.tsx
+++ b/src/app/_components/MainCarousel.tsx
@@ -35,6 +35,7 @@ const MainCarousel = () => {
                 src={img.src}
                 alt={img.alt}
                 className="object-cover"
+                priority={idx === 0}
               />
               <Button
                 asChild

--- a/src/app/_components/MainCarousel.tsx
+++ b/src/app/_components/MainCarousel.tsx
@@ -13,17 +13,23 @@ import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
 import { FaChevronRight } from 'react-icons/fa6';
+import Autoplay from 'embla-carousel-autoplay';
 
 const images = [
   { src: '/images/found_main01.jpg', alt: 'main01' },
   { src: '/images/found_main02.jpg', alt: 'main02' },
   { src: '/images/found_main03.jpg', alt: 'main03' },
 ];
+const autoplayOptions = { delay: 1000 * 2, stopOnInteraction: false };
 
 const MainCarousel = () => {
   return (
     <div className="relative h-[calc(100vh-100px)]">
-      <Carousel opts={{ loop: true }} className="w-full ">
+      <Carousel
+        opts={{ loop: true }}
+        plugins={[Autoplay(autoplayOptions)]}
+        className="w-full "
+      >
         <CarouselContent className="m-0">
           {images.map((img, idx) => (
             <CarouselItem

--- a/src/app/appointment/page.tsx
+++ b/src/app/appointment/page.tsx
@@ -39,7 +39,7 @@ const AppointmentPage = () => {
   };
 
   return (
-    <div className="container mx-auto py-10">
+    <div className="container mx-auto max-w-5xl rounded-2xl shadow-xl border border-gray-200 p-10 bg-white">
       <AppointmentForm
         newAppointment={newAppointment}
         handleChange={handleChange}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- ex) #이슈번호, #이슈번호

<br>

## 📝 작업 내용

> 플러그인 설치 후 2초마다 이동으로 설정
> 간단한 css 수정

<br>


https://github.com/user-attachments/assets/abdba0e8-4ef2-4d8e-b798-42adc2dff2ae


<br>

## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?