### PR TITLE
Feat/#65 로그인 여부에 따른 Header 조건부 렌더링

### DIFF
--- a/src/app/(layout)/Header.tsx
+++ b/src/app/(layout)/Header.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { PATH } from '@/constants/constants';
 import Image from 'next/image';
 import Link from 'next/link';

--- a/src/app/(layout)/Header.tsx
+++ b/src/app/(layout)/Header.tsx
@@ -3,63 +3,26 @@
 import { PATH } from '@/constants/constants';
 import Image from 'next/image';
 import Link from 'next/link';
-import React, { useState, useEffect } from 'react';
+import HeaderNav from './HeaderNav';
 
 const Header = () => {
-  const [shadow, setShadow] = useState(false);
-
-  const handleScroll = () => {
-    if (window.scrollY > 0) {
-      setShadow(true);
-    } else {
-      setShadow(false);
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, []);
-
   return (
     <header
-      className={`w-full fixed top-0 flex justify-between text-main1 text-title-sm font-light px-[100px] h-[100px] items-center transition-shadow duration-300 z-10 bg-white ${
-        shadow ? 'shadow-[0px_4px_10px_0px_rgba(0,_0,_0,_0.1)]' : ''
-      }`}
+      className="w-full fixed top-0 flex justify-between text-main1 px-[70px] h-14 items-center z-50 bg-white shadow-[0px_4px_10px_0px_rgba(0,_0,_0,_0.1)]
+      }"
     >
-      <Link href={PATH.HOME} className="relative w-[150px] h-[75px]">
+      <Link href={PATH.HOME} className="relative w-[100px] h-[75px]">
         <Image
           src="/images/found_logo.png"
           alt="Found 로고"
           fill
           priority
-          sizes="150px"
+          sizes="100px"
           style={{ objectFit: 'contain' }}
         />
       </Link>
-      <nav>
-        <ul className="flex gap-[50px]">
-          <li>
-            <Link href={PATH.MATELIST}>운동메이트</Link>
-          </li>
-          <li>
-            <Link href={PATH.LOGIN}>로그인</Link>
-          </li>
-          <li>
-            <Link href={PATH.SIGNUP}>회원가입</Link>
-          </li>
-          {/* 아래는 개발 편의를 위해 만들어 둠 */}
-          <li>
-            <Link href={PATH.MYPAGE}>마이페이지</Link>
-          </li>
-          <li>
-            <Link href={PATH.CHATTING}>채팅</Link>
-          </li>
-        </ul>
-      </nav>
+
+      <HeaderNav />
     </header>
   );
 };

--- a/src/app/(layout)/HeaderNav.tsx
+++ b/src/app/(layout)/HeaderNav.tsx
@@ -24,7 +24,7 @@ const HeaderNav = () => {
       <nav className="w-1/4">
         {/* 로그인 상태 */}
         <ul className="w-full flex justify-between items-center text-main1 text-text-lg">
-          {isAuthenticated && (
+          {isAuthenticated ? (
             <>
               <li className={navLi}>
                 <Link href={`${PATH.MYPAGE}/${user?.id}`}>
@@ -37,14 +37,8 @@ const HeaderNav = () => {
                   LOG OUT
                 </button>
               </li>
-              <li className={navLi}>
-                <Link href={PATH.MATELIST}>FOUNIES</Link>
-              </li>
             </>
-          )}
-
-          {/* 로그아웃 상태 */}
-          {!isAuthenticated && (
+          ) : (
             <>
               <li className={navLi}>
                 <Link href={PATH.LOGIN}>LOG IN</Link>
@@ -52,11 +46,11 @@ const HeaderNav = () => {
               <li className={navLi}>
                 <Link href={PATH.SIGNUP}>SIGN UP</Link>
               </li>
-              <li className={navLi}>
-                <Link href={PATH.MATELIST}>FOUNIES</Link>
-              </li>
             </>
           )}
+          <li className={navLi}>
+            <Link href={PATH.MATELIST}>FOUNIES</Link>
+          </li>
         </ul>
       </nav>
     </>

--- a/src/app/(layout)/HeaderNav.tsx
+++ b/src/app/(layout)/HeaderNav.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { PATH } from '@/constants/constants';
+import Link from 'next/link';
+import { useAuthStore } from '@/providers/AuthProvider';
+import { logout } from '@/services/usersServices';
+
+const HeaderNav = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const user = useAuthStore((state) => state.user);
+  const setLogout = useAuthStore((state) => state.setLogout);
+
+  const handleLogout = async () => {
+    await logout();
+    setLogout();
+  };
+
+  return (
+    <>
+      <nav className="w-1/4">
+        {/* 로그인 상태 */}
+        <ul className="w-full flex justify-between items-center text-main1 text-text-lg">
+          {isAuthenticated && (
+            <>
+              <li className={navLi}>
+                <Link href={`${PATH.MYPAGE}/${user?.id}`}>
+                  {user?.nickname}
+                  <span className="text-medium-gray"> 님</span>
+                </Link>
+              </li>
+              <li className={navLi}>
+                <button type="button" onClick={handleLogout}>
+                  LOG OUT
+                </button>
+              </li>
+              <li className={navLi}>
+                <Link href={PATH.MATELIST}>FOUNIES</Link>
+              </li>
+            </>
+          )}
+
+          {/* 로그아웃 상태 */}
+          {!isAuthenticated && (
+            <>
+              <li className={navLi}>
+                <Link href={PATH.LOGIN}>LOG IN</Link>
+              </li>
+              <li className={navLi}>
+                <Link href={PATH.SIGNUP}>SIGN UP</Link>
+              </li>
+              <li className={navLi}>
+                <Link href={PATH.MATELIST}>FOUNIES</Link>
+              </li>
+            </>
+          )}
+        </ul>
+      </nav>
+    </>
+  );
+};
+
+//style
+const navLi = 'font-medium duration-200 hover:scale-105';
+
+export default HeaderNav;

--- a/src/app/(layout)/HeaderNav.tsx
+++ b/src/app/(layout)/HeaderNav.tsx
@@ -4,6 +4,7 @@ import { PATH } from '@/constants/constants';
 import Link from 'next/link';
 import { useAuthStore } from '@/providers/AuthProvider';
 import { logout } from '@/services/usersServices';
+import { toast } from '@/hooks/useToast';
 
 const HeaderNav = () => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
@@ -13,6 +14,9 @@ const HeaderNav = () => {
   const handleLogout = async () => {
     await logout();
     setLogout();
+
+    //사용자 알림
+    toast({ description: '로그아웃 되었습니다!' });
   };
 
   return (

--- a/src/app/_components/MainCarousel.tsx
+++ b/src/app/_components/MainCarousel.tsx
@@ -22,13 +22,13 @@ const images = [
 
 const MainCarousel = () => {
   return (
-    <div className="relative h-[calc(100vh-100px)]">
+    <div className="relative h-[calc(100vh-56px)]">
       <Carousel opts={{ loop: true }} className="w-full ">
         <CarouselContent className="m-0">
           {images.map((img, idx) => (
             <CarouselItem
               key={idx}
-              className="w-full relative h-[calc(100vh-100px)]"
+              className="w-full relative h-[calc(100vh-56px)]"
             >
               <Image
                 fill

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
         <AuthStoreProvider>
           <Header />
           <Providers>
-            <main className="pt-[100px] w-screen">
+            <main className="pt-14 w-screen">
               {children}
               {modal}
             </main>

--- a/src/hooks/useAuthValidation.ts
+++ b/src/hooks/useAuthValidation.ts
@@ -9,7 +9,7 @@ import { useForm } from 'react-hook-form';
 import { AuthInputs, UserData } from '@/types/users';
 import { login, signup } from '@/services/usersServices';
 import { useRouter } from 'next/navigation';
-import { createAuthStore } from '@/services/userStore';
+import { useAuthStore } from '@/providers/AuthProvider';
 
 export const useAuthValidation = (mode: string) => {
   // 경로 이동을 위한 route
@@ -57,6 +57,8 @@ export const useAuthValidation = (mode: string) => {
   } = useForm<AuthInputs>();
 
   // 로그인 로직
+  const loginWithZustand = useAuthStore((state) => state.setLogin);
+
   const handleSubmitLogin = async (
     data: Pick<AuthInputs, 'email' | 'password'>,
   ) => {
@@ -101,8 +103,7 @@ export const useAuthValidation = (mode: string) => {
           profile: data.user?.user_metadata.profile,
         };
 
-        const store = createAuthStore();
-        store.getState().setLogin(userData);
+        loginWithZustand(userData);
 
         // 성공시 사용자 알람
         toast({
@@ -170,7 +171,7 @@ export const useAuthValidation = (mode: string) => {
           bio,
           address: `${address.place} ${address.detailPlace}`,
           categories,
-          profile: `/images/found_default_profile${Math.floor(Math.random() * 6)}.png`,
+          profile: `/images/found_default_profile0${Math.floor(Math.random() * 6)}.png`,
         },
       },
     };

--- a/src/services/usersServices.ts
+++ b/src/services/usersServices.ts
@@ -81,3 +81,8 @@ export const fetchUserIdFinding = async (sub: string) => {
 
   return data;
 };
+
+//-----logout 로직-----
+export const logout = async () => {
+  await supabase.auth.signOut();
+};

--- a/src/services/usersServices.ts
+++ b/src/services/usersServices.ts
@@ -2,6 +2,7 @@ import { AuthInputs, UserMetaData } from '@/types/users';
 import { supabase } from './supabaseClient';
 import { AuthError, Session, User } from '@supabase/supabase-js';
 import { QUERY_KEY } from '@/constants/constants';
+import { toast } from '@/hooks/useToast';
 
 //-----로그인 로직-----
 export const login = async (
@@ -84,5 +85,14 @@ export const fetchUserIdFinding = async (sub: string) => {
 
 //-----logout 로직-----
 export const logout = async () => {
-  await supabase.auth.signOut();
+  try {
+    await supabase.auth.signOut();
+  } catch (error) {
+    console.error('로그아웃 에러 : ', error);
+    //사용자 알람
+    toast({
+      variant: 'destructive',
+      description: '로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요!',
+    });
+  }
 };

--- a/src/ui/shadcn/toast.tsx
+++ b/src/ui/shadcn/toast.tsx
@@ -28,7 +28,7 @@ const toastVariants = cva(
   {
     variants: {
       variant: {
-        default: 'border bg-background text-foreground',
+        default: 'bg-main2 text-main1',
         destructive:
           'destructive group border-destructive bg-destructive text-destructive-foreground',
       },
@@ -61,7 +61,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-main2 px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
       className,
     )}
     {...props}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #65

<br>

## 📝 작업 내용

> 로그인 여부에 따른 Header 조건부 렌더링 구현
> 로그아웃 버튼 구현

<br>

## 🖼 스크린샷

<img width="1440" alt="Screenshot 2025-03-25 at 3 54 07 PM" src="https://github.com/user-attachments/assets/e862e174-1d05-4ca3-9480-20c66a33ea46" />

![Screen Recording 2025-03-25 at 3 54 25 PM](https://github.com/user-attachments/assets/a1d2e3ab-7f43-43a6-b631-3b4a17624df7)

![Uploading Screenshot 2025-03-25 at 4.24.51 PM.png…]()

<br>

## 💬리뷰 요구사항

> Header의 height값이 `100px` => `h-14 (56px)`로 변경되었습니다.
> 작업 페이지에서 확인 후 컨텐츠 높이 수정해주시면 감사드리겠습니다! 🙇